### PR TITLE
Add-balance-due-button

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -38,12 +38,19 @@ ActiveAdmin.register_page "Dashboard" do
     end
 
     columns do
+      if current_application_settings.allow_payments?
+        div do
+          span do
+            button_to 'Send Balance Due email', send_balance_due_url, class: 'btn'
+          end
+        end
+      end
       column do
         panel "#{ApplicationSetting.get_current_app_year} Applicants who accepted their offer (#{Application.application_accepted.count})" do
           table_for Application.application_accepted.sort.reverse do
-            column("Name") {|a| a.display_name }
-            column("User") { |u| link_to(u.user.email, admin_application_path(u.id)) }
+            column("Applicant") { |u| link_to(u.display_name, admin_application_path(u.id)) }
             column("Offer Date") { |od| od.offer_status_date }
+            column("Balance Due") { |a| number_to_currency a.balance_due }  
           end
         end
       end

--- a/app/mailers/balance_due_mailer.rb
+++ b/app/mailers/balance_due_mailer.rb
@@ -3,6 +3,6 @@ class BalanceDueMailer < ApplicationMailer
   def outstanding_balance
     @application = params[:app]
     @current_application_settings = ApplicationSetting.get_current_app_settings
-    mail(to: @application.email, subject: "Your #{@current_application_settings.contest_year} Bear River Writers’ Conference has an outstanding balance.")
+    mail(to: @application.email, subject: "Your #{@current_application_settings.contest_year} Bear River Writers’ Conference payment due notification.")
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -77,6 +77,22 @@ class Application < ApplicationRecord
     user.total_paid
   end
 
+  def lodging_cost
+    Lodging.find_by(description: self.lodging_selection).cost.to_f 
+  end
+
+  def partner_registration_cost
+    self.partner_registration.cost.to_f
+  end
+
+  def total_cost
+    lodging_cost + partner_registration_cost
+  end
+
+  def balance_due
+    total_cost - total_user_has_paid
+  end
+
   def first_workshop_instructor
     Workshop.find(workshop_selection1).instructor
   end
@@ -104,7 +120,6 @@ class Application < ApplicationRecord
   scope :application_accepted, -> { active_conference_applications.where("offer_status = ?", "registration_accepted") }
 
   scope :application_offered, -> { active_conference_applications.where("offer_status = ? or offer_status = ?", "registration_offered", "special_offer_application") }
-
 
   scope :subscription_selected, -> { active_conference_applications.where("subscription = ?", true) }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,9 @@ Rails.application.routes.draw do
   post '/send_offer/:id', to: 'application_settings#send_offer', as: 'send_offer'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
+  # Send email to applicants who a balance due
+  post '/send_balance_due', to: 'applications#send_balance_due', as: 'send_balance_due'
+
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -105,14 +105,22 @@ ApplicationSetting.create!([
   {
     opendate: Time.now,
     application_buffer: 50,
+    registration_fee: 25,
+    lottery_buffer: 50,
+    application_open_period: 48,
     contest_year: Time.now.year,
+    subscription_cost: 25,
     time_zone: "EST",
     active_application: true,
     application_open_directions: "<p>Welcome to the Bear River Application Portal!</p> <p>Effective for the 2022 conference date, application will now be open for a period of 48 hours. Once the 48-hour window has ended, registrants will be chosen by a random lottery system and notified via email. This email will contain directions and a link where registrants are able to pay the $25 application fee to confirm their spot in the 2022 Bear River Writers’ Conference. Payment must be received within 48 hours of notification for registrants to confirm their place in the conference. If payment is not received, the next registrant on the waitlist will be notified via email.</p> <p>Good luck and we hope to see you at Bear River in the Spring!</p>",
     application_closed_directions: "<p>Thank you for your interest in Bear River. Unfortunately, the application is currently closed. The application period will reopen in April 2023. Please feel free to reach out with any questions to bearriver-questions@umich.edu.</p> <p></p>",
-    application_acceptance_directions: "<p>Dear Writer:</p> <p>Please log-in and pay the application fee to confirm your spot in the Bear River Writers' Conference. Again, if confirmation of payment is not received within 48 hours, we will forfeit the spot to the next person on the waitlist.</p> <p>Please feel free to reach out to bearriver-questions@umich.edu if you have any questions.</p> <p>We look forward to seeing you in the Spring!</p>",
+    registration_acceptance_directions: "<p>Dear Writer:</p> <p>Please log-in and pay the application fee to confirm your spot in the Bear River Writers' Conference. Again, if confirmation of payment is not received within 48 hours, we will forfeit the spot to the next person on the waitlist.</p> <p>Please feel free to reach out to bearriver-questions@umich.edu if you have any questions.</p> <p>We look forward to seeing you in the Spring!</p>",
     payments_directions: "<p>Dear Writer:</p> <p>Thank you for your Bear River Writers' Conference Application.</p> <p>Half of your Bear River Writers' Conference tuition is due by March 15, 2022. The remainder is due on April 30, 2022.</p> <p>Lastly, this year, conference registrants may add a Michigan Quarterly Review (MQR) subscription to their application. For $25 (a discounted rate for Bear River participants), you will receive 4 issues of MQR beginning July 1, 2022. Michigan Quarterly Review is an interdisciplinary and international literary journal, combining distinctive voices in poetry, fiction, and nonfiction, as well as works in translation. Writers are able to submit to MQR for publication.</p> <p>Please feel free to reach out to bearriver-questions@umich.edu if you have any questions.</p>",
+    balance_due_email_message:  "Balance due email message needs to be added.",
     subscription_directions: "<p>Subscribe to the Michigan Quarterly Review at a discounted rate.</p>",
+    special_scholarship_acceptance_directions: "Special scholarship acceptance directions need to be added.",
+    special_offer_invite_email: "Special offer invite email needs to be added.",
+    application_confirm_email_message: "Thank you for your Bear River Writers' Conference Application. You will be notified via email if you have been accepted to the conference.",
     lottery_won_email: "Congratulations! You’ve been selected by our randomized lottery to attend the 2022 Bear River Writers’ Conference. To confirm your spot, a $25 deposit is required at this time. You have 48 hours to make this initial deposit, after which your spot will be forfeited to the next person on the waitlist. After payment is received your spot will be officially confirmed. We’ll be in touch with you at the beginning of March with your room and workshop assignments at which point you’ll be directed to make final payments. If you have any questions, please email bearriver-questions@umich.edu. We look forward to seeing you in the Spring!",
     lottery_lost_email: "We are sorry, but you have not been selected by our random lottery system to attend the 2022 Bear River Writers’ Conference. You have been placed on our waiting list. If a spot opens up, we will notify you immediately via email. We thank you for your interest in Bear River. If you have any questions, please email bearriver-questions@umich.edu."
   }


### PR DESCRIPTION
This PR creates a method and mailer support for sending balance due messages to current applicants in the Bear River application.
The button to trigger this activity is on the Dashboard in Active Admin and will only display if the Allow Payments is set to true.